### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/yourkit`
-The Paketo YourKit Buildpack is a Cloud Native Buildpack that contributes the [YourKit][y] Agent and configures it to
+The Paketo Buildpack for YourKit is a Cloud Native Buildpack that contributes the [YourKit][y] Agent and configures it to
 connect to the service.
 
 [y]: https://www.yourkit.com

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/yourkit"
   id = "paketo-buildpacks/yourkit"
   keywords = ["yourkit", "agent", "profiler"]
-  name = "Paketo YourKit Buildpack"
+  name = "Paketo Buildpack for YourKit"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo YourKit Buildpack' to 'Paketo Buildpack for YourKit'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
